### PR TITLE
Feature: search projects by name

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "nest build -b swc",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "nest start",
-    "start:db": "docker-compose up mongo",
+    "start:db": "docker compose up mongo",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/sample-data/models/user.model.ts
+++ b/sample-data/models/user.model.ts
@@ -3,6 +3,6 @@ export interface User {
     firstName: string
     lastName: string
     email: string
-    passwoord: string
+    password: string
     projectsId: string[]
 }

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -6,6 +6,7 @@ import {
     Param,
     Post,
     Put,
+    Query,
     Req,
     UseGuards,
 } from '@nestjs/common'
@@ -50,10 +51,16 @@ export class ProjectController {
         return projects
     }
 
+    @Get('search')
+    async searchProjects(@Query() query) {
+        const name = query['name']
+        const projects = await this.projectService.findProjectsByName(name)
+        return projects
+    }
+
     @Get('shared')
-    async getAllSharedProjects(@Req() req: { user: { id: string } }) {
-        const { id: userId } = req.user
-        const projects = await this.projectService.findSharedProjects(userId)
+    async getAllSharedProjects() {
+        const projects = await this.projectService.findSharedProjects()
         return projects
     }
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -4,6 +4,7 @@ import { Model } from 'mongoose'
 import { UserService } from '../user/user.service'
 import { ProjectDto } from './project.dto'
 import { Project } from './project.schema'
+import { escapeRegExp } from './utils/escape_string'
 
 @Injectable()
 export class ProjectService {
@@ -62,9 +63,15 @@ export class ProjectService {
         return this.projectModel.find({ owner })
     }
 
-    async findSharedProjects(userId: string) {
+    async findProjectsByName(name: string) {
+        return this.projectModel.find({
+            name: new RegExp(escapeRegExp(name), 'i'),
+        })
+    }
+
+    async findSharedProjects() {
         //const user = await this.userService.findById(userId)
-        return null // user.sharedProjects TODO: borrar
+        return [] // user.sharedProjects TODO: borrar
     }
     async update(id: string, updated: ProjectDto) {
         return this.projectModel.findOneAndUpdate({ _id: id }, updated)

--- a/src/project/utils/escape_string.ts
+++ b/src/project/utils/escape_string.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+}


### PR DESCRIPTION
Se agrega el endpoint `/projects/search?name=ejemplo` donde se pueden buscar todos los proyectos por nombre. En una segunda iteración restaría validar que el usuario es admin (ahora mismo solo funciona si estas logueado con cualquier rol)
Actualmente busca por "name" así que no funciona con el field viejo "titulo"